### PR TITLE
Handle NoneType from get_project_channel_data() and add debug logging…

### DIFF
--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -425,10 +425,22 @@ def get_parsed_export_maps(config, strip_texture_set=False):
     outputs = substance_painter.export.list_project_textures(config)
     templates = get_export_templates(config, strip_folder=False)
 
-    # Get all color spaces set for the current project
+    print("DEBUG: get_project_channel_data() returned:", get_project_channel_data())
+
+    #((AR-130525)rdo-modification
+    # Fixed issue with get_project_channel_data() returning None.
+    # Now safely handles the 'data' key being None to avoid crashing during colorSpace parsing.)
+    
     project_colorspaces = set(
-        data["colorSpace"] for data in get_project_channel_data().values()
+        data["colorSpace"]
+        for data in get_project_channel_data().values()
+        if data and "colorSpace" in data
     )
+
+    # Get all color spaces set for the current project
+    #project_colorspaces = set(
+        #data["colorSpace"] for data in get_project_channel_data().values()
+    #)
 
     # Get current project mesh path and project path to explicitly match
     # the $mesh and $project tokens

--- a/client/ayon_substancepainter/version.py
+++ b/client/ayon_substancepainter/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'substancepainter' version."""
-__version__ = "0.2.8+dev"
+__version__ = "0.2.8+dev.rdo.1"

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "substancepainter"
 title = "Substance Painter"
-version = "0.2.8+dev"
+version = "0.2.8+dev.rdo.1"
 app_host_name = "substancepainter"
 client_dir = "ayon_substancepainter"
 


### PR DESCRIPTION
- Avoid crash when 'data' is None in get_project_channel_data()
- Improve stability when parsing colorSpace info
