### PR TITLE
Fix Substance Painter colorspace query handling for updated path format

### DIFF
--- a/client/ayon_substancepainter/api/colorspace.py
+++ b/client/ayon_substancepainter/api/colorspace.py
@@ -8,7 +8,6 @@ More information see:
   - https://substance3d.adobe.com/documentation/spdoc/color-management-with-opencolorio-225969419.html
 
 """  # noqa E501
-print("DEBUG COLORSPACE FILE LOADED FROM:", __file__) 
 import substance_painter.export
 import substance_painter.js
 import json
@@ -105,12 +104,6 @@ def get_project_channel_data():
 
     def _get_query_output(config):
         result = substance_painter.export.list_project_textures(config)
-
-        print("DEBUG list_project_textures result:", repr(result))
-        print("DEBUG exportList:", repr(config.get("exportList")))
-        print("DEBUG map channels:", repr(config["exportPresets"][0]["maps"][0].get("channels")))
-        print("DEBUG map parameters:", repr(config["exportPresets"][0]["maps"][0].get("parameters")))
-
         if not result:
             raise RuntimeError(
                 "Substance Painter export query returned no results. "

--- a/client/ayon_substancepainter/api/colorspace.py
+++ b/client/ayon_substancepainter/api/colorspace.py
@@ -8,9 +8,11 @@ More information see:
   - https://substance3d.adobe.com/documentation/spdoc/color-management-with-opencolorio-225969419.html
 
 """  # noqa E501
+print("DEBUG COLORSPACE FILE LOADED FROM:", __file__) 
 import substance_painter.export
 import substance_painter.js
 import json
+import os
 
 from .lib import (
     get_document_structure,
@@ -102,13 +104,49 @@ def get_project_channel_data():
     }
 
     def _get_query_output(config):
-        # Return the basename of the single output path we defined
         result = substance_painter.export.list_project_textures(config)
-        path = next(iter(result.values()))[0]
-        # strip extension and slash since we know relevant json data starts
-        # and ends with { and } characters
-        path = path.strip("/\\.exr")
-        return json.loads(path)
+
+        print("DEBUG list_project_textures result:", repr(result))
+        print("DEBUG exportList:", repr(config.get("exportList")))
+        print("DEBUG map channels:", repr(config["exportPresets"][0]["maps"][0].get("channels")))
+        print("DEBUG map parameters:", repr(config["exportPresets"][0]["maps"][0].get("parameters")))
+
+        if not result:
+            raise RuntimeError(
+                "Substance Painter export query returned no results. "
+                f"Config was: exportList={repr(config.get('exportList'))}, "
+                f"channels={repr(config['exportPresets'][0]['maps'][0].get('channels'))}"
+            )
+
+        first_value = next(iter(result.values()), None)
+        if not first_value:
+            raise RuntimeError(
+                "Substance Painter export query returned an empty path list. "
+                f"Raw result: {repr(result)}"
+            )
+
+        path = first_value[0]
+        print(f"DEBUG path: {repr(path)}")
+
+        if not path or not str(path).strip():
+            raise RuntimeError(
+                f"Empty output path from Substance Painter export query. Raw result: {repr(result)}"
+            )
+
+        normalized_path = str(path).replace("\\", "/").rstrip("/")
+        filename = normalized_path.split("/")[-1]
+
+        print(f"DEBUG normalized_path: {repr(normalized_path)}")
+        print(f"DEBUG filename: {repr(filename)}")
+
+        stem = os.path.splitext(filename)[0].strip()
+
+        print(f"DEBUG stem: {repr(stem)}")
+
+        if not stem:
+            raise RuntimeError(
+                f"Empty filename stem from Substance Painter export query. Path was: {repr(path)}"
+            )
 
     # Query for each type of channel (color and data)
     color_channel, data_channel = _get_first_color_and_data_stack_and_channel()

--- a/client/ayon_substancepainter/version.py
+++ b/client/ayon_substancepainter/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'substancepainter' version."""
-__version__ = "0.2.12+dev.rdo.1"
+__version__ = "0.2.12+dev.rdo.2"

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "substancepainter"
 title = "Substance Painter"
-version = "0.2.12+dev.rdo.1"
+version = "0.2.12+dev.rdo.2"
 app_host_name = "substancepainter"
 client_dir = "ayon_substancepainter"
 project_can_override_addon_version = True


### PR DESCRIPTION
After a recent Substance Painter update, the format of the data returned during the colorspace query changed. Our tool was relying on the previous format, which caused publishing to fail. This change updates the logic to handle the new format more safely, ensuring publishing works as expected again.