### PR TITLE
feat(USER-735): add pipe-controlled substance export preset setting

### DIFF
--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -1095,4 +1095,4 @@ def set_layer_stack_opacity(node_ids, channel_types):
             for channel, opacity in original_opacity_values:
                 node.set_opacity(opacity, channel)
 
- 
+

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -195,6 +195,86 @@ def check_texture_resolution_before_write(parent=None):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# (USER-735)rdo-modification
+# Pipe-controlled export preset (CPV setting).
+# get_pipe_export_preset_path reads the configured .spexp path from Ayon
+# settings and validates it exists on disk — hard failure, no silent fallback.
+# get_pipe_export_preset_url registers the preset under an ayon_pipe shelf
+# and returns the resource URL ready to use in exportPresetUrl.)
+# ---------------------------------------------------------------------------
+
+
+def get_pipe_export_preset_path():
+    """Return the pipe-controlled export preset path from project settings.
+
+    Reads ``substancepainter > pipe_template > export_preset_path``.
+    Raises ``FileNotFoundError`` if the path is set but missing on disk.
+
+    Returns:
+        str: Path to the ``.spexp`` file, or empty string if unconfigured.
+    """
+    try:
+        from ayon_core.pipeline import get_current_project_settings
+        project_settings = get_current_project_settings()
+        path = (
+            project_settings
+            .get("substancepainter", {})
+            .get("pipe_template", {})
+            .get("export_preset_path", "")
+        )
+    except Exception as exc:
+        log.warning("Could not read pipe export preset settings: %s", exc)
+        return ""
+
+    if not path:
+        return ""
+
+    if not os.path.isfile(path):
+        raise FileNotFoundError(
+            f"SubstancePresetNotFound: {path!r}\n"
+            "Check substancepainter > Pipe Template > Export Preset Path "
+            "in Ayon Studio Settings."
+        )
+
+    return path
+
+
+def get_pipe_export_preset_url():
+    """Return the resource URL for the pipe-controlled export preset.
+
+    Registers the preset under a dedicated ``ayon_pipe`` shelf and returns
+    its resource URL for use in ``exportPresetUrl``.
+
+    Returns:
+        str: Resource URL, or empty string if no pipe preset is configured.
+    """
+    path = get_pipe_export_preset_path()
+    if not path:
+        return ""
+
+    preset_dir = os.path.dirname(path)
+    preset_name = os.path.splitext(os.path.basename(path))[0]
+
+    shelf_name = "ayon_pipe"
+    try:
+        load_shelf(preset_dir, name=shelf_name)
+    except ValueError as exc:
+        log.warning("Failed to register pipe preset shelf: %s", exc)
+        return ""
+
+    resource = substance_painter.resource.ResourceID(
+        context=shelf_name,
+        name=preset_name,
+    )
+    return resource.url()
+
+
+# ---------------------------------------------------------------------------
+# End USER-735
+# ---------------------------------------------------------------------------
+
+
 def get_export_presets():
     """Return Export Preset resource URLs for all available Export Presets.
 
@@ -1014,3 +1094,5 @@ def set_layer_stack_opacity(node_ids, channel_types):
         for node in excluded_nodes:
             for channel, opacity in original_opacity_values:
                 node.set_opacity(opacity, channel)
+
+ 

--- a/client/ayon_substancepainter/plugins/create/create_textures.py
+++ b/client/ayon_substancepainter/plugins/create/create_textures.py
@@ -14,7 +14,11 @@ from ayon_substancepainter.api.pipeline import (
     set_instances,
     remove_instance
 )
-from ayon_substancepainter.api.lib import get_export_presets
+# (USER-735)rdo-modification
+from ayon_substancepainter.api.lib import (
+    get_export_presets,
+    get_pipe_export_preset_url, 
+)
 
 import substance_painter
 import substance_painter.project
@@ -179,6 +183,8 @@ class CreateTextures(Creator):
                             "all channels"),
             EnumDef("exportPresetUrl",
                     items=get_export_presets(),
+                    # (USER-735)rdo-modification
+                    default=get_pipe_export_preset_url() or None,  
                     label="Output Template"),
             BoolDef("allowSkippedMaps",
                     label="Allow Skipped Output Maps",
@@ -273,3 +279,4 @@ class CreateTextures(Creator):
                         tooltip="Select Layer Stack(s) for exporting")
             )
         return attr_defs + self.get_instance_attr_defs()
+    

--- a/client/ayon_substancepainter/plugins/publish/validate_ouput_maps.py
+++ b/client/ayon_substancepainter/plugins/publish/validate_ouput_maps.py
@@ -7,6 +7,7 @@ import substance_painter.export
 
 from ayon_core.pipeline import PublishValidationError
 
+from ayon_substancepainter.api.lib import get_pipe_export_preset_url
 
 class ValidateOutputMaps(pyblish.api.InstancePlugin):
     """Validate all output maps for Output Template are generated.
@@ -23,6 +24,14 @@ class ValidateOutputMaps(pyblish.api.InstancePlugin):
     families = ["textureSet"]
 
     def process(self, instance):
+
+        # (USER-735)[RDO-modification]
+        # Enforce that the active export preset matches the pipe-controlled
+        # preset when one is configured. Blocks publish if an artist has
+        # swapped it out, ensuring colour management and naming conventions
+        # are always met.)
+        self._validate_pipe_preset(instance)
+        # End USER-735
 
         config = instance.data["exportConfig"]
 
@@ -114,6 +123,31 @@ class ValidateOutputMaps(pyblish.api.InstancePlugin):
                 title="Missing output maps"
             )
 
+
+    # (USER-735)[RDO-modification]
+    def _validate_pipe_preset(self, instance):
+        """Raise if a pipe preset is configured but not used on this instance.
+
+        Args:
+            instance (pyblish.api.Instance): The texture set instance.
+        """
+        pipe_url = get_pipe_export_preset_url()
+        if not pipe_url:
+            return
+
+        creator_attrs = instance.data.get("creator_attributes", {})
+        active_url = creator_attrs.get("exportPresetUrl", "")
+        if active_url != pipe_url:
+            raise PublishValidationError(
+                f"Export preset does not match the pipe-controlled preset.\n\n"
+                f"Expected: {pipe_url}\n"
+                f"Active:   {active_url}\n\n"
+                "Change the Output Template on the instance to the "
+                "pipe preset before publishing.",
+                title="Wrong export preset"
+            )
+    # End USER-735
+
     def get_invalid_channels(self, instance, config):
         """Function to get invalid channel(s) from export channel
         filtering
@@ -151,3 +185,4 @@ class ValidateOutputMaps(pyblish.api.InstancePlugin):
                         invalid_channel.append(channel)
 
         return invalid_channel
+    

--- a/client/ayon_substancepainter/version.py
+++ b/client/ayon_substancepainter/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'substancepainter' version."""
-__version__ = "0.2.12+dev.rdo.3"
+__version__ = "0.2.12+dev.rdo.4"

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "substancepainter"
 title = "Substance Painter"
-version = "0.2.12+dev.rdo.3"
+version = "0.2.12+dev.rdo.4"
 app_host_name = "substancepainter"
 client_dir = "ayon_substancepainter"
 project_can_override_addon_version = True

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -3,6 +3,7 @@ from .imageio import ImageIOSettings, DEFAULT_IMAGEIO_SETTINGS
 from .creator_plugins import CreatorsModel, DEFAULT_CREATOR_SETTINGS
 from .load_plugins import LoadersModel, DEFAULT_LOADER_SETTINGS
 from .publish_plugins import PublishersModel, DEFAULT_PUBLISH_SETTINGS
+from .pipe_template import PipeTemplateSettings, DEFAULT_PIPE_TEMPLATE_SETTINGS
 
 
 class ShelvesSettingsModel(BaseSettingsModel):
@@ -15,6 +16,10 @@ class SubstancePainterSettings(BaseSettingsModel):
     imageio: ImageIOSettings = SettingsField(
         default_factory=ImageIOSettings,
         title="Color Management (ImageIO)"
+    )
+    pipe_template: PipeTemplateSettings = SettingsField(
+        default_factory=PipeTemplateSettings,
+        title="Pipe Template"
     )
     shelves: list[ShelvesSettingsModel] = SettingsField(
         default_factory=list,
@@ -30,8 +35,10 @@ class SubstancePainterSettings(BaseSettingsModel):
 
 DEFAULT_SPAINTER_SETTINGS = {
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
+    "pipe_template": DEFAULT_PIPE_TEMPLATE_SETTINGS,
     "shelves": [],
     "create": DEFAULT_CREATOR_SETTINGS,
     "load": DEFAULT_LOADER_SETTINGS,
     "publish": DEFAULT_PUBLISH_SETTINGS,
 }
+


### PR DESCRIPTION

Added a new Pipe Template section to the Substance Painter addon settings that lets pipe control the default CPV export preset via Ayon.
 The preset path is set at studio level and applies to all shows, with the option to override per project for edge cases. The creator now defaults to the pipe preset when opening the texture publish dialog, and the validator blocks publish if the wrong preset is selected.