### PR TITLE
Fix false positive validation blocks on legitimately skipped texture channels (allowSkippedMaps)

### DIFF
--- a/client/ayon_substancepainter/plugins/publish/extract_textures.py
+++ b/client/ayon_substancepainter/plugins/publish/extract_textures.py
@@ -1,3 +1,5 @@
+import os
+
 import substance_painter.project
 import substance_painter.export
 from ayon_core.pipeline import KnownPublishError, publish
@@ -24,7 +26,6 @@ class ExtractTextures(publish.Extractor,
     order = publish.Extractor.order - 0.1
 
     def process(self, instance):
-
         substance_painter.project.execute_when_not_busy(
             lambda: self._export_texture_set(instance)
         )
@@ -35,13 +36,11 @@ class ExtractTextures(publish.Extractor,
         context = instance.context
         for image_instance in instance:
             representation = next(iter(image_instance.data["representations"]))
-
             colorspace = image_instance.data.get("colorspace")
             if not colorspace:
                 self.log.debug("No color space data present for instance: "
                                f"{image_instance}")
                 continue
-
             self.set_representation_colorspace(representation,
                                                context=context,
                                                colorspace=colorspace)
@@ -59,20 +58,21 @@ class ExtractTextures(publish.Extractor,
 
         Raises:
             KnownPublishError: If the export fails.
+
         """
         config = instance.data["exportConfig"]
         creator_attrs = instance.data["creator_attributes"]
         export_channel = creator_attrs.get("exportChannel", [])
         node_ids = instance.data.get("selected_node_id", [])
+
         with set_layer_stack_opacity(node_ids, export_channel):
             result = substance_painter.export.export_project_textures(config)
-
             if result.status != substance_painter.export.ExportStatus.Success:
                 raise KnownPublishError(
                     "Failed to export texture set: {}".format(result.message)
                 )
 
-            # Log what files we generated
+            exported_filenames = set()
             for (texture_set_name, stack_name), maps in (
                 result.textures.items()
             ):
@@ -82,3 +82,28 @@ class ExtractTextures(publish.Extractor,
                 )
                 for texture_map in maps:
                     self.log.info(f"Exported texture: {texture_map}")
+                    exported_filenames.add(os.path.basename(texture_map))
+
+        #((RDO-NEW)rdo-modification
+        # allowSkippedMaps may cause a channel's file to be skipped entirely.
+        # Drop image instances whose representation was not actually written.
+        context = instance.context
+        for image_instance in list(instance):
+            representation = next(
+                iter(image_instance.data.get("representations", [])), None
+            )
+            if representation is None:
+                continue
+
+            files = representation.get("files", [])
+            if isinstance(files, str):
+                files = [files]
+
+            if files and not any(f in exported_filenames for f in files):
+                self.log.debug(
+                    "Skipped channel, no export for %s: %s",
+                    image_instance, files
+                )
+                instance.remove(image_instance)
+                context.remove(image_instance)
+        #((RDO-NEW)rdo-modification-end

--- a/client/ayon_substancepainter/version.py
+++ b/client/ayon_substancepainter/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'substancepainter' version."""
-__version__ = "0.2.12+dev.rdo.3"
+__version__ = "0.2.12+dev.rdo.4"

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "substancepainter"
 title = "Substance Painter"
-version = "0.2.12+dev.rdo.3"
+version = "0.2.12+dev.rdo.4"
 app_host_name = "substancepainter"
 client_dir = "ayon_substancepainter"
 project_can_override_addon_version = True


### PR DESCRIPTION
Fixes false publish blocks caused by allowSkippedMaps. When a channel has no content, Substance Painter skips writing its file, but the collector doesn't know this ahead of time, so the resolution validator was flagging these skipped files as missing and blocking publish.
ExtractTextures now checks the real export result and drops any image instance whose file wasn't actually written, before the validator sees it.
Tested on Wed_Wabbit/wimbleypinkbodya — publish now goes through clean.